### PR TITLE
ARK Genesis "TribeId" fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 cd ark-savegame-toolkit
 mvn install
 #
-cd ark-tools
+cd ../ark-tools
 mvn install
 ```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# ark-tools
+Tools to work with the binary files of ark. Extract information, manipulate them or write them from scratch.
+
+## HowTo build
+```
+# Debian Buster
+#----------------
+apt-get install maven openjdk-11-jre openjdk-11-jdk git
+git clone https://github.com/Qowyn/ark-savegame-toolkit.git
+git clone https://github.com/McBane87/ark-tools.git
+#
+export MAVEN_OPTS='-Dmaven.wagon.http.ssl.insecure=true -Dmaven.wagon.http.ssl.allowall=true -Dmaven.wagon.http.ssl.ignore.validity.dates=true'
+export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+#
+cd ark-savegame-toolkit
+mvn install
+#
+cd ark-tools
+mvn install
+```

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 		<dependency>
 			<groupId>qowyn.ark</groupId>
 			<artifactId>ark-savegame-toolkit</artifactId>
-			<version>0.8.1</version>
+			<version>0.8.2</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/qowyn/ark/tools/data/Player.java
+++ b/src/main/java/qowyn/ark/tools/data/Player.java
@@ -106,7 +106,7 @@ public class Player {
     uniqueId = myData.getPropertyValue("UniqueID", StructUniqueNetIdRepl.class);
     savedNetworkAddress = myData.getPropertyValue("SavedNetworkAddress", String.class);
     playerName = myData.getPropertyValue("PlayerName", String.class);
-    tribeId = myData.findPropertyValue("TribeID", Integer.class).orElse(0);
+    tribeId = myData.findPropertyValue("TribeID", Integer.class).orElse(myData.findPropertyValue("TribeId", Integer.class).orElse(0));
     playerDataVersion = myData.findPropertyValue("PlayerDataVersion", Integer.class).orElse(0);
     spawnDayNumber = myData.findPropertyValue("SpawnDayNumber", Integer.class).orElse(0);
     spawnDayTime = myData.findPropertyValue("SpawnDayTime", Float.class).orElse(0.0f);

--- a/src/main/java/qowyn/ark/tools/data/Tribe.java
+++ b/src/main/java/qowyn/ark/tools/data/Tribe.java
@@ -64,7 +64,7 @@ public class Tribe {
 
     tribeName = tribeData.findPropertyValue("TribeName", String.class).orElse("");
     ownerPlayerDataId = tribeData.findPropertyValue("OwnerPlayerDataID", Integer.class).orElse(0);
-    tribeId = tribeData.findPropertyValue("TribeID", Integer.class).orElse(0);
+    tribeId = tribeData.findPropertyValue("TribeID", Integer.class).orElse(tribeData.findPropertyValue("TribeId", Integer.class).orElse(0));
 
     ArkArrayString membersNames = tribeData.getPropertyValue("MembersPlayerName", ArkArrayString.class);
     if (membersNames != null) {


### PR DESCRIPTION
Looks like in Genesis savefiles the "TribeID" property was renamed to "TribeId". But only in Genesis as far as I can tell.